### PR TITLE
Add Model jivelite800x480

### DIFF
--- a/src/StyleSettings.pm
+++ b/src/StyleSettings.pm
@@ -164,7 +164,7 @@ sub handler {
 		if($item->{'id'} =~ /^models$/) {
 			$item->{'type'} = 'checkboxes';
 			my @values;
-			foreach my $value (qw(controller radio touch)) {
+			foreach my $value (qw(controller radio touch jivelite800x480)) {
 				my %v = (
 					'value' => $value
 				);
@@ -967,7 +967,7 @@ sub saveHandler {
 	my $oldStyleName = $styleName;
 	my $name = $params->{'property_name'};
 	my $models = "";
-	foreach my $model (qw(controller radio touch)) {
+	foreach my $model (qw(controller radio touch jivelite800x480)) {
 		if($params->{'property_models_'.$model}) {
 			if($models ne "") {
 				$models.=",";


### PR DESCRIPTION
Add new model "jivelite800x480"
Allows CCH to create/edit customclock screensavers for new model type
for Jivelite version of CustomClock using 800x480 screen size.
